### PR TITLE
gallery: avoid using deprecated DOMNode events

### DIFF
--- a/src/components/Gallery.svelte
+++ b/src/components/Gallery.svelte
@@ -33,14 +33,19 @@
     }
   }
 
-  onMount(draw)
+  onMount(() => {
+    draw();
+
+    const observer = new MutationObserver(draw);
+    observer.observe(slotHolder, { childList: true })
+
+    return () => observer.disconnect()
+  });
 </script>
 
 <div
   class="slot-holder"
   bind:this={slotHolder}
-  on:DOMNodeInserted={draw}
-  on:DOMNodeRemoved={draw}
 >
   <slot />
 </div>


### PR DESCRIPTION
This fixes the album page on recent Chrome versions, since the DOMNode events are not supported anymore.